### PR TITLE
Add PMO Command Center web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# WebApp1
+# PMO Command Center
+
+A lightweight, single-page portfolio dashboard tailored for project managers and PMO leads. The app runs entirely in the browser and can be hosted directly from this repository (for example via GitHub Pages).
+
+## Features
+
+- 📊 **Portfolio snapshot** – real-time counts of active, on-track, and at-risk projects plus the next milestone.
+- 🗂️ **Project list** – sortable project cards with progress, budget usage, RAG health, and quick actions.
+- ⚠️ **Risk & action log** – consolidated open risks with mitigation notes and owners.
+- 🗓️ **Milestone timeline** – chronological list of upcoming project end dates.
+- ➕ **Add projects** – capture portfolio entries (including tags and a first risk) that persist in local storage.
+- 📤 **Export summary** – download a plain-text portfolio digest for status reports or leadership updates.
+
+## Getting started
+
+1. Open `index.html` in any modern browser. No build tools or backend services are required.
+2. Use the filters to focus on a specific quarter, status, or keyword.
+3. Press **+ Add Project** to capture new work. Data persists locally in the browser via `localStorage`.
+4. Use **Log Risk** and **Mark Complete** buttons on each project card to keep the portfolio current.
+5. Click **Export Summary** to generate a shareable text report.
+
+> ℹ️ Initial sample data is provided to demonstrate the experience. Clear your browser storage to reset the workspace.
+
+## Deploying with GitHub Pages
+
+1. Push the repository to GitHub.
+2. In the repository settings, enable **GitHub Pages** and choose the main branch (root folder).
+3. Visit the published URL to interact with the dashboard.
+
+## License
+
+This project is available under the MIT License. See `LICENSE` if provided by the repository owner.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,488 @@
+const storageKey = 'pmo-projects-v1';
+
+const healthOrder = ['green', 'amber', 'red'];
+
+const sampleProjects = [
+  {
+    id: 'p-001',
+    name: 'ERP Stabilisation & Rollout',
+    manager: 'Naomi Glenn',
+    quarter: 'Q3',
+    priority: 1,
+    status: 'In Progress',
+    health: 'amber',
+    progress: 62,
+    budget: 58,
+    startDate: '2024-03-04',
+    endDate: '2024-09-30',
+    tags: ['ERP', 'Finance', 'Operations'],
+    risks: [
+      {
+        id: 'r-001',
+        summary: 'Data migration defect rate may delay go-live by two weeks.',
+        mitigation: 'Add weekend QA sprints and engage vendor specialists for triage.',
+        owner: 'Naomi Glenn',
+        dueDate: '2024-08-30',
+        status: 'Monitoring',
+      },
+    ],
+  },
+  {
+    id: 'p-002',
+    name: 'Customer Portal Modernisation',
+    manager: 'Priyanka Iyer',
+    quarter: 'Q4',
+    priority: 2,
+    status: 'At Risk',
+    health: 'red',
+    progress: 38,
+    budget: 64,
+    startDate: '2024-05-13',
+    endDate: '2024-12-06',
+    tags: ['Customer Experience', 'Web'],
+    risks: [
+      {
+        id: 'r-002',
+        summary: 'Vendor API contract changes blocked integration sprint.',
+        mitigation: 'Escalated change request; working on interim stub service.',
+        owner: 'Priyanka Iyer',
+        dueDate: '2024-07-26',
+        status: 'Action Required',
+      },
+      {
+        id: 'r-003',
+        summary: 'UAT resource availability limited due to fiscal year end.',
+        mitigation: 'Securing temporary contractors and shifting non-critical scope.',
+        owner: 'PMO Office',
+        dueDate: '2024-08-09',
+        status: 'Mitigating',
+      },
+    ],
+  },
+  {
+    id: 'p-003',
+    name: 'Data Governance Operating Model',
+    manager: 'Chris Ortega',
+    quarter: 'Q2',
+    priority: 3,
+    status: 'In Progress',
+    health: 'green',
+    progress: 81,
+    budget: 48,
+    startDate: '2024-02-05',
+    endDate: '2024-07-19',
+    tags: ['Data', 'Compliance'],
+    risks: [
+      {
+        id: 'r-004',
+        summary: 'Change champion engagement dropping in APAC region.',
+        mitigation: 'Schedule executive townhall and add weekly checkpoints.',
+        owner: 'Chris Ortega',
+        dueDate: '2024-07-05',
+        status: 'In Progress',
+      },
+    ],
+  },
+  {
+    id: 'p-004',
+    name: 'AI Assisted Support Pilot',
+    manager: 'Lana Petrov',
+    quarter: 'Q3',
+    priority: 2,
+    status: 'Not Started',
+    health: 'amber',
+    progress: 12,
+    budget: 15,
+    startDate: '2024-06-10',
+    endDate: '2024-10-18',
+    tags: ['AI', 'Service Desk'],
+    risks: [],
+  },
+];
+
+const state = {
+  projects: loadProjects(),
+};
+
+const elements = {
+  projectList: document.querySelector('#projectList'),
+  projectCount: document.querySelector('#projectCount'),
+  riskList: document.querySelector('#riskList'),
+  riskCount: document.querySelector('#riskCount'),
+  timeline: document.querySelector('#timeline'),
+  statusFilter: document.querySelector('#statusFilter'),
+  quarterFilter: document.querySelector('#quarterFilter'),
+  searchInput: document.querySelector('#searchInput'),
+  sortSelect: document.querySelector('#sortSelect'),
+  addProjectBtn: document.querySelector('#addProjectBtn'),
+  exportBtn: document.querySelector('#exportBtn'),
+  summary: {
+    active: document.querySelector('#activeProjects'),
+    activeFootnote: document.querySelector('#activeProjectsChange'),
+    onTrack: document.querySelector('#onTrackProjects'),
+    onTrackPercent: document.querySelector('#onTrackPercent'),
+    atRisk: document.querySelector('#atRiskProjects'),
+    atRiskPercent: document.querySelector('#atRiskPercent'),
+    milestones: document.querySelector('#upcomingMilestones'),
+    nextMilestone: document.querySelector('#nextMilestone'),
+  },
+  dialog: document.querySelector('#projectDialog'),
+  form: document.querySelector('#projectForm'),
+  closeDialog: document.querySelector('#closeDialog'),
+};
+
+const projectTemplate = document.querySelector('#projectCardTemplate');
+const riskTemplate = document.querySelector('#riskItemTemplate');
+
+document.addEventListener('DOMContentLoaded', () => {
+  render();
+  setupEventListeners();
+});
+
+function loadProjects() {
+  const raw = localStorage.getItem(storageKey);
+  if (!raw) {
+    return sampleProjects;
+  }
+  try {
+    const stored = JSON.parse(raw);
+    if (Array.isArray(stored) && stored.length) {
+      return stored;
+    }
+    return sampleProjects;
+  } catch (error) {
+    console.warn('Failed to parse stored projects, resetting data.', error);
+    return sampleProjects;
+  }
+}
+
+function saveProjects() {
+  localStorage.setItem(storageKey, JSON.stringify(state.projects));
+}
+
+function setupEventListeners() {
+  [elements.statusFilter, elements.quarterFilter, elements.sortSelect].forEach((el) =>
+    el.addEventListener('change', render)
+  );
+  elements.searchInput.addEventListener('input', debounce(render, 200));
+  elements.addProjectBtn.addEventListener('click', () => {
+    elements.form.reset();
+    elements.dialog.showModal();
+  });
+  elements.closeDialog.addEventListener('click', () => elements.dialog.close());
+  elements.form.addEventListener('submit', handleAddProject);
+  elements.exportBtn.addEventListener('click', exportSummary);
+}
+
+function render() {
+  const filtered = applyFilters(structuredClone(state.projects));
+  renderSummary(filtered);
+  renderProjects(filtered);
+  renderRisks(filtered);
+  renderTimeline(filtered);
+}
+
+function applyFilters(projects) {
+  const status = elements.statusFilter.value;
+  const quarter = elements.quarterFilter.value;
+  const search = elements.searchInput.value.trim().toLowerCase();
+  const sort = elements.sortSelect.value;
+
+  let result = projects;
+  if (status !== 'all') {
+    result = result.filter((project) => project.status === status);
+  }
+  if (quarter !== 'all') {
+    result = result.filter((project) => project.quarter === quarter);
+  }
+  if (search) {
+    result = result.filter((project) => {
+      const haystack = [project.name, project.manager, project.tags?.join(' ')].join(' ').toLowerCase();
+      return haystack.includes(search);
+    });
+  }
+
+  const sorters = {
+    priority: (a, b) => a.priority - b.priority,
+    health: (a, b) => healthOrder.indexOf(a.health) - healthOrder.indexOf(b.health),
+    progress: (a, b) => b.progress - a.progress,
+    endDate: (a, b) => new Date(a.endDate) - new Date(b.endDate),
+  };
+
+  return result.sort(sorters[sort]);
+}
+
+function renderSummary(projects) {
+  const activeProjects = state.projects.filter((project) => project.status !== 'Completed');
+  const completed = state.projects.length - activeProjects.length;
+  const onTrack = state.projects.filter((project) => project.health === 'green' && project.status !== 'Completed');
+  const atRisk = state.projects.filter(
+    (project) => project.status === 'At Risk' || project.health === 'red'
+  );
+
+  elements.summary.active.textContent = activeProjects.length;
+  elements.summary.activeFootnote.textContent = `${completed} completed`;
+  elements.summary.onTrack.textContent = onTrack.length;
+  elements.summary.onTrackPercent.textContent = `${Math.round(
+    (onTrack.length / Math.max(activeProjects.length, 1)) * 100
+  )}% of active`;
+  elements.summary.atRisk.textContent = atRisk.length;
+  elements.summary.atRiskPercent.textContent = `${Math.round(
+    (atRisk.length / Math.max(state.projects.length, 1)) * 100
+  )}% of total`;
+
+  const upcoming = projects
+    .filter((project) => project.status !== 'Completed')
+    .map((project) => ({
+      ...project,
+      endDateObj: new Date(project.endDate),
+    }))
+    .filter((project) => !Number.isNaN(project.endDateObj.getTime()))
+    .sort((a, b) => a.endDateObj - b.endDateObj);
+
+  const upcomingWindow = upcoming.filter((project) => project.endDateObj >= new Date());
+  elements.summary.milestones.textContent = upcomingWindow.length;
+  if (upcomingWindow.length) {
+    const next = upcomingWindow[0];
+    elements.summary.nextMilestone.textContent = `${next.name} • ${formatDate(next.endDate)}`;
+  } else {
+    elements.summary.nextMilestone.textContent = 'No future milestones';
+  }
+}
+
+function renderProjects(projects) {
+  elements.projectList.replaceChildren();
+  elements.projectCount.textContent = `${projects.length} project${projects.length === 1 ? '' : 's'}`;
+
+  projects.forEach((project) => {
+    const fragment = projectTemplate.content.cloneNode(true);
+    const card = fragment.querySelector('.project-card');
+    card.dataset.id = project.id;
+
+    fragment.querySelector('.project-name').textContent = project.name;
+    fragment.querySelector('.project-meta').textContent = `${project.manager} • ${project.quarter} • Priority ${project.priority}`;
+    fragment.querySelector('.health-indicator').style.background =
+      project.health === 'green' ? 'var(--green)' : project.health === 'amber' ? 'var(--amber)' : 'var(--red)';
+    fragment.querySelector('.project-status').textContent = project.status;
+    fragment.querySelector('.project-progress').textContent = project.progress;
+    fragment.querySelector('.project-budget').textContent = project.budget;
+    fragment.querySelector('.project-dates').textContent = `${formatDate(project.startDate)} – ${formatDate(
+      project.endDate
+    )}`;
+    fragment.querySelector('.progress-fill').style.width = `${project.progress}%`;
+
+    const tagList = fragment.querySelector('.tag-list');
+    (project.tags || []).forEach((tag) => {
+      const tagEl = document.createElement('span');
+      tagEl.textContent = tag;
+      tagList.appendChild(tagEl);
+    });
+
+    fragment.querySelector('.action-view').addEventListener('click', () => showProjectDetails(project));
+    fragment.querySelector('.action-risk').addEventListener('click', () => logRisk(project.id));
+    fragment.querySelector('.action-complete').addEventListener('click', () => markComplete(project.id));
+
+    elements.projectList.appendChild(fragment);
+  });
+}
+
+function renderRisks(projects) {
+  elements.riskList.replaceChildren();
+  const risks = projects
+    .flatMap((project) => (project.risks || []).map((risk) => ({ ...risk, project })))
+    .filter((risk) => risk.status !== 'Closed');
+
+  elements.riskCount.textContent = `${risks.length} open risk${risks.length === 1 ? '' : 's'}`;
+
+  if (!risks.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'All clear! No open portfolio risks.';
+    empty.className = 'empty-state';
+    elements.riskList.appendChild(empty);
+    return;
+  }
+
+  risks
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate))
+    .forEach((risk) => {
+      const fragment = riskTemplate.content.cloneNode(true);
+      fragment.querySelector('.risk-title').textContent = risk.summary;
+      fragment.querySelector('.risk-detail').textContent = risk.mitigation;
+      fragment.querySelector('.risk-meta').textContent = `${risk.project.name} • Owner: ${risk.owner} • Due ${formatDate(
+        risk.dueDate
+      )}`;
+      elements.riskList.appendChild(fragment);
+    });
+}
+
+function renderTimeline(projects) {
+  elements.timeline.replaceChildren();
+  const milestones = projects
+    .filter((project) => project.status !== 'Completed')
+    .map((project) => ({
+      id: project.id,
+      name: project.name,
+      manager: project.manager,
+      endDate: project.endDate,
+      status: project.status,
+      health: project.health,
+    }))
+    .filter((item) => !Number.isNaN(new Date(item.endDate).getTime()))
+    .sort((a, b) => new Date(a.endDate) - new Date(b.endDate));
+
+  if (!milestones.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No upcoming milestones. Add projects to populate the timeline.';
+    empty.className = 'empty-state';
+    elements.timeline.appendChild(empty);
+    return;
+  }
+
+  milestones.forEach((milestone) => {
+    const item = document.createElement('div');
+    item.className = 'timeline-item';
+    item.innerHTML = `
+      <h4>${milestone.name}</h4>
+      <p>${formatDate(milestone.endDate)} • ${milestone.manager}</p>
+      <p>Status: ${milestone.status} • Health: ${milestone.health.toUpperCase()}</p>
+    `;
+    elements.timeline.appendChild(item);
+  });
+}
+
+function handleAddProject(event) {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  const project = {
+    id: crypto.randomUUID ? crypto.randomUUID() : `p-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    name: formData.get('name').trim(),
+    manager: formData.get('manager').trim(),
+    quarter: formData.get('quarter'),
+    priority: Number(formData.get('priority')),
+    status: formData.get('status'),
+    health: formData.get('health'),
+    progress: Number(formData.get('progress')),
+    budget: Number(formData.get('budget')),
+    startDate: formData.get('startDate'),
+    endDate: formData.get('endDate'),
+    tags: formData
+      .get('tags')
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+    risks: [],
+  };
+
+  const riskNote = formData.get('risks').trim();
+  if (riskNote) {
+    project.risks.push({
+      id: `r-${Date.now()}`,
+      summary: riskNote,
+      mitigation: 'Owner to define mitigation plan.',
+      owner: project.manager,
+      dueDate: project.endDate,
+      status: 'New',
+    });
+  }
+
+  state.projects.push(project);
+  saveProjects();
+  elements.dialog.close();
+  render();
+}
+
+function showProjectDetails(project) {
+  const risks = project.risks?.length
+    ? project.risks
+        .map((risk) => `• ${risk.summary}\n  Mitigation: ${risk.mitigation}\n  Owner: ${risk.owner} • Due ${formatDate(risk.dueDate)}\n`)
+        .join('\n')
+    : 'No logged risks.';
+
+  const detail = `Project: ${project.name}\nManager: ${project.manager}\nQuarter: ${project.quarter}\nStatus: ${project.status}\nProgress: ${project.progress}%\nBudget Used: ${project.budget}%\nTimeline: ${formatDate(project.startDate)} – ${formatDate(project.endDate)}\nTags: ${project.tags.join(', ') || 'None'}\n\nRisks:\n${risks}`;
+  window.alert(detail);
+}
+
+function logRisk(projectId) {
+  const project = state.projects.find((item) => item.id === projectId);
+  if (!project) return;
+
+  const summary = window.prompt('Describe the risk or issue:');
+  if (!summary) return;
+  const mitigation = window.prompt('Describe the mitigation or next action:') || 'Mitigation plan TBD.';
+  const dueDate = window.prompt('Target mitigation date (YYYY-MM-DD):', project.endDate) || project.endDate;
+
+  project.risks = project.risks || [];
+  project.risks.push({
+    id: `r-${Date.now()}`,
+    summary,
+    mitigation,
+    owner: project.manager,
+    dueDate,
+    status: 'Action Required',
+  });
+
+  saveProjects();
+  render();
+}
+
+function markComplete(projectId) {
+  const project = state.projects.find((item) => item.id === projectId);
+  if (!project) return;
+  if (!window.confirm(`Mark ${project.name} as complete?`)) {
+    return;
+  }
+  project.status = 'Completed';
+  project.health = 'green';
+  project.progress = 100;
+  saveProjects();
+  render();
+}
+
+function exportSummary() {
+  const header = 'Portfolio Summary';
+  const lines = [header, '='.repeat(header.length), ''];
+
+  state.projects.forEach((project) => {
+    lines.push(
+      `${project.name} (${project.status})\nManager: ${project.manager}\nProgress: ${project.progress}% | Budget Used: ${project.budget}%\nTimeline: ${formatDate(project.startDate)} – ${formatDate(project.endDate)}\nTags: ${project.tags.join(', ') || 'None'}\nRisks:`
+    );
+    if (!project.risks?.length) {
+      lines.push('  - None');
+    } else {
+      project.risks.forEach((risk) => {
+        lines.push(
+          `  - ${risk.summary} (Owner: ${risk.owner}, Due: ${formatDate(risk.dueDate)}, Status: ${risk.status})`
+        );
+      });
+    }
+    lines.push('');
+  });
+
+  const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const anchor = Object.assign(document.createElement('a'), {
+    href: url,
+    download: `portfolio-summary-${new Date().toISOString().slice(0, 10)}.txt`,
+  });
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+function formatDate(value) {
+  const date = value ? new Date(value) : null;
+  if (!date || Number.isNaN(date.getTime())) return 'TBD';
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function debounce(fn, wait = 200) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), wait);
+  };
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PMO Command Center</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="branding">
+        <h1>PMO Command Center</h1>
+        <p class="subtitle">
+          A lightweight portfolio dashboard to help project managers and PMO leaders monitor delivery health.
+        </p>
+      </div>
+      <div class="actions">
+        <button id="addProjectBtn" class="primary">+ Add Project</button>
+        <button id="exportBtn" class="ghost">Export Summary</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="summary-grid" aria-label="Portfolio summary metrics">
+        <article class="summary-card">
+          <span class="summary-label">Active Projects</span>
+          <span class="summary-value" id="activeProjects">0</span>
+          <span class="summary-footnote" id="activeProjectsChange"></span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">On Track</span>
+          <span class="summary-value" id="onTrackProjects">0</span>
+          <span class="summary-footnote" id="onTrackPercent"></span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">At Risk</span>
+          <span class="summary-value" id="atRiskProjects">0</span>
+          <span class="summary-footnote" id="atRiskPercent"></span>
+        </article>
+        <article class="summary-card">
+          <span class="summary-label">Upcoming Milestones</span>
+          <span class="summary-value" id="upcomingMilestones">0</span>
+          <span class="summary-footnote" id="nextMilestone"></span>
+        </article>
+      </section>
+
+      <section class="filters" aria-label="Project filters">
+        <div class="field">
+          <label for="statusFilter">Status</label>
+          <select id="statusFilter">
+            <option value="all">All</option>
+            <option value="Not Started">Not Started</option>
+            <option value="In Progress">In Progress</option>
+            <option value="At Risk">At Risk</option>
+            <option value="Completed">Completed</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="quarterFilter">Quarter</label>
+          <select id="quarterFilter">
+            <option value="all">All</option>
+            <option value="Q1">Q1</option>
+            <option value="Q2">Q2</option>
+            <option value="Q3">Q3</option>
+            <option value="Q4">Q4</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="searchInput">Search</label>
+          <input id="searchInput" type="search" placeholder="Project, manager, or tag" />
+        </div>
+        <div class="field">
+          <label for="sortSelect">Sort by</label>
+          <select id="sortSelect">
+            <option value="priority">Priority</option>
+            <option value="health">Health</option>
+            <option value="progress">Progress</option>
+            <option value="endDate">End date</option>
+          </select>
+        </div>
+      </section>
+
+      <section class="content-grid">
+        <section class="panel" aria-label="Project list">
+          <div class="panel-header">
+            <h2>Portfolio View</h2>
+            <span id="projectCount" class="chip">0 projects</span>
+          </div>
+          <div id="projectList" class="project-list" role="list"></div>
+        </section>
+
+        <section class="panel" aria-label="Risk radar">
+          <div class="panel-header">
+            <h2>Risk &amp; Action Log</h2>
+            <span class="chip" id="riskCount">0 open risks</span>
+          </div>
+          <ul id="riskList" class="risk-list"></ul>
+        </section>
+
+        <section class="panel span-2" aria-label="Timeline">
+          <div class="panel-header">
+            <h2>Milestone Timeline</h2>
+          </div>
+          <div id="timeline" class="timeline"></div>
+        </section>
+      </section>
+    </main>
+
+    <dialog id="projectDialog">
+      <form id="projectForm" method="dialog">
+        <header>
+          <h3>Add Project</h3>
+          <button type="button" class="icon" id="closeDialog" aria-label="Close dialog">&times;</button>
+        </header>
+        <div class="form-grid">
+          <label>
+            Name
+            <input name="name" required />
+          </label>
+          <label>
+            Manager
+            <input name="manager" required />
+          </label>
+          <label>
+            Quarter
+            <select name="quarter" required>
+              <option value="Q1">Q1</option>
+              <option value="Q2">Q2</option>
+              <option value="Q3">Q3</option>
+              <option value="Q4">Q4</option>
+            </select>
+          </label>
+          <label>
+            Priority
+            <select name="priority" required>
+              <option value="1">1 - Critical</option>
+              <option value="2">2 - High</option>
+              <option value="3">3 - Medium</option>
+              <option value="4">4 - Low</option>
+            </select>
+          </label>
+          <label>
+            Status
+            <select name="status" required>
+              <option>Not Started</option>
+              <option>In Progress</option>
+              <option>At Risk</option>
+              <option>Completed</option>
+            </select>
+          </label>
+          <label>
+            Health (RAG)
+            <select name="health" required>
+              <option value="green">Green</option>
+              <option value="amber">Amber</option>
+              <option value="red">Red</option>
+            </select>
+          </label>
+          <label>
+            Progress (%)
+            <input name="progress" type="number" min="0" max="100" value="0" required />
+          </label>
+          <label>
+            Budget Used (%)
+            <input name="budget" type="number" min="0" max="100" value="0" required />
+          </label>
+          <label>
+            Start Date
+            <input name="startDate" type="date" required />
+          </label>
+          <label>
+            End Date
+            <input name="endDate" type="date" required />
+          </label>
+          <label class="span-2">
+            Tags (comma separated)
+            <input name="tags" placeholder="ERP, customer experience" />
+          </label>
+          <label class="span-2">
+            Risks &amp; Actions
+            <textarea name="risks" rows="3" placeholder="Describe the top risks and planned mitigations"></textarea>
+          </label>
+        </div>
+        <footer>
+          <button type="reset" class="ghost">Clear</button>
+          <button type="submit" class="primary">Save Project</button>
+        </footer>
+      </form>
+    </dialog>
+
+    <template id="projectCardTemplate">
+      <article class="project-card" role="listitem">
+        <header>
+          <div>
+            <h3 class="project-name"></h3>
+            <p class="project-meta"></p>
+          </div>
+          <span class="health-indicator" aria-label="Health"></span>
+        </header>
+        <div class="project-body">
+          <dl class="project-stats">
+            <div>
+              <dt>Status</dt>
+              <dd class="project-status"></dd>
+            </div>
+            <div>
+              <dt>Progress</dt>
+              <dd><span class="project-progress"></span>%</dd>
+            </div>
+            <div>
+              <dt>Budget Used</dt>
+              <dd><span class="project-budget"></span>%</dd>
+            </div>
+            <div>
+              <dt>Timeline</dt>
+              <dd class="project-dates"></dd>
+            </div>
+          </dl>
+          <div class="progress-bar" aria-hidden="true">
+            <span class="progress-fill"></span>
+          </div>
+          <div class="tag-list"></div>
+        </div>
+        <footer>
+          <button class="ghost action-view">Details</button>
+          <button class="ghost action-risk">Log Risk</button>
+          <button class="ghost action-complete">Mark Complete</button>
+        </footer>
+      </article>
+    </template>
+
+    <template id="riskItemTemplate">
+      <li>
+        <div class="risk-title"></div>
+        <p class="risk-detail"></p>
+        <span class="risk-meta"></span>
+      </li>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,478 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f7f9fc;
+  --surface: #ffffff;
+  --surface-dark: #14191f;
+  --text: #1a1d21;
+  --text-muted: #52606d;
+  --border: #d8dee6;
+  --primary: #3d5afe;
+  --primary-dark: #2f3dd6;
+  --green: #1ea672;
+  --amber: #f5a524;
+  --red: #e63b3b;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, rgba(61, 90, 254, 0.05), transparent 280px), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  padding: 2.5rem clamp(1.25rem, 3vw, 3rem) 1.5rem;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: -0.03em;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  max-width: 34rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  font: inherit;
+  border-radius: 999px;
+  padding: 0.6rem 1.25rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+  box-shadow: 0 12px 25px -15px rgba(61, 90, 254, 0.8);
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+button.ghost {
+  background: rgba(61, 90, 254, 0.08);
+  color: var(--primary);
+  border-color: rgba(61, 90, 254, 0.15);
+}
+
+button.ghost:hover {
+  background: rgba(61, 90, 254, 0.12);
+}
+
+button.icon {
+  border-radius: 50%;
+  width: 2.25rem;
+  height: 2.25rem;
+  font-size: 1.4rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+main {
+  padding: 0 clamp(1.25rem, 3vw, 3rem) 4rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summary-card {
+  background: var(--surface);
+  border-radius: 1.25rem;
+  padding: 1.4rem 1.6rem;
+  border: 1px solid rgba(82, 96, 109, 0.08);
+  box-shadow: 0 20px 45px -35px rgba(22, 35, 51, 0.45);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.summary-label {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.summary-value {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.summary-footnote {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+  align-items: end;
+}
+
+.field label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.field select,
+.field input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--border);
+  font: inherit;
+  background: white;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(82, 96, 109, 0.08);
+  box-shadow: 0 25px 50px -40px rgba(22, 35, 51, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chip {
+  background: rgba(61, 90, 254, 0.08);
+  color: var(--primary);
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+}
+
+.project-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card {
+  border: 1px solid rgba(82, 96, 109, 0.12);
+  border-radius: 1.2rem;
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+  background: white;
+}
+
+.project-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.project-name {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.project-meta {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.health-indicator {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+}
+
+.project-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.project-stats dt {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.project-stats dd {
+  margin: 0.15rem 0 0;
+  font-weight: 600;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(82, 96, 109, 0.16);
+  overflow: hidden;
+}
+
+.progress-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--primary);
+  transition: width 0.4s ease;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag-list span {
+  background: rgba(82, 96, 109, 0.08);
+  border-radius: 0.6rem;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.project-card footer {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.project-card footer button {
+  flex: 1;
+  border-radius: 0.75rem;
+  border-color: rgba(82, 96, 109, 0.12);
+  background: rgba(82, 96, 109, 0.05);
+  color: var(--text);
+}
+
+.project-card footer button:hover {
+  background: rgba(82, 96, 109, 0.1);
+}
+
+.risk-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.risk-list li {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(82, 96, 109, 0.12);
+  padding: 1rem 1.1rem;
+  background: rgba(230, 59, 59, 0.04);
+}
+
+.empty-state {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(82, 96, 109, 0.3);
+  color: var(--text-muted);
+  background: rgba(82, 96, 109, 0.05);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.risk-title {
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.risk-detail {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.risk-meta {
+  display: inline-flex;
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline-item {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(82, 96, 109, 0.12);
+  background: rgba(61, 90, 254, 0.05);
+}
+
+.timeline-item h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.timeline-item p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+dialog {
+  border: none;
+  border-radius: 1.25rem;
+  padding: 0;
+  max-width: 640px;
+  width: 100%;
+  box-shadow: 0 25px 80px rgba(22, 35, 51, 0.35);
+}
+
+dialog::backdrop {
+  background: rgba(10, 16, 26, 0.55);
+}
+
+#projectForm {
+  padding: 1rem 1.75rem 1.75rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+#projectForm header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  border-radius: 0.8rem;
+  border: 1px solid var(--border);
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  background: rgba(247, 249, 252, 0.8);
+}
+
+.form-grid textarea {
+  resize: vertical;
+}
+
+.form-grid .span-2 {
+  grid-column: span 2;
+}
+
+#projectForm footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.span-2 {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .project-card footer {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(180deg, rgba(61, 90, 254, 0.16), transparent 280px), #0f141a;
+    color: #f5f7fa;
+  }
+
+  .summary-card,
+  .panel,
+  .project-card,
+  dialog {
+    background: rgba(15, 20, 26, 0.95);
+    border-color: rgba(255, 255, 255, 0.04);
+  }
+
+  .project-card footer button {
+    background: rgba(255, 255, 255, 0.05);
+    color: inherit;
+  }
+
+  .field select,
+  .field input,
+  .form-grid input,
+  .form-grid select,
+  .form-grid textarea {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: inherit;
+  }
+
+  .chip {
+    background: rgba(61, 90, 254, 0.25);
+  }
+
+  .risk-list li {
+    background: rgba(230, 59, 59, 0.1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page PMO Command Center dashboard with portfolio summary, project list, risk log, and timeline
- implement interactive project management logic with local storage persistence and exportable summaries
- style the experience with responsive, dark-mode-friendly design and document usage in the README

## Testing
- python3 -m http.server 8000 (manual UI verification)


------
https://chatgpt.com/codex/tasks/task_e_68e42e57e5c4832782167fa8a593b435